### PR TITLE
Adding of RSA-SHA256 signature and oauth_body_hash parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _testmain.go
 *.a
 6.out
 example
+.idea

--- a/README.markdown
+++ b/README.markdown
@@ -3,17 +3,23 @@
 [![GoDoc](https://godoc.org/github.com/gomodule/oauth1/oauth?status.svg)](https://godoc.org/github.com/gomodule/oauth1/oauth)
 [![Build Status](https://travis-ci.org/gomodule/oauth1.svg?branch=master)](https://travis-ci.org/gomodule/oauth1)
 
-OAuth1 is a [Go](https://golang.org/) client for the OAuth 1.0, OAuth 1.0a and
-[RFC 5849](https://tools.ietf.org/html/rfc5849) Protocols. The package supports
-HMAC-SHA1, RSA-SHA1 and PLAINTEXT signatures.
+OAuth1 is a [Go](https://golang.org/) client for the OAuth 1.0, OAuth 1.0a and [RFC 5849](https://tools.ietf.org/html/rfc5849) Protocols.
+The package supports the following signatures:
+* HMAC-SHA1
+* HMAC-SHA256
+* RSA-SHA1
+* PLAINTEXT
+
 
 ## Installation
 
-    go get github.com/gomodule/oauth1/oauth
+```bash
+$ go get -u github.com/gomodule/oauth1/oauth
+```
 
 ## License
 
-oauth1 is available under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
+`oauth1` is available under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 ## Documentation
     

--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,17 @@ The package supports the following signatures:
 
 ```bash
 $ go get -u github.com/gomodule/oauth1/oauth
+```  
+  
+Import it in your code:
+    
+```go
+import "github.com/gomodule/oauth1/oauth"
 ```
+
+### Prerequisite
+
+`oauth1` uses the context package requiring Go 1.7 or later.
 
 ## License
 

--- a/examples/appengine/app.go
+++ b/examples/appengine/app.go
@@ -15,13 +15,12 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"text/template"
-
-	"golang.org/x/net/context"
 
 	"github.com/gomodule/oauth1/oauth"
 

--- a/examples/appengine/app.go
+++ b/examples/appengine/app.go
@@ -39,7 +39,7 @@ var oauthClient = oauth.Client{
 	TokenRequestURI:               "https://api.twitter.com/oauth/access_token",
 }
 
-// context stores context associated with an HTTP request.
+// Context stores context associated with an HTTP request.
 type Context struct {
 	c context.Context
 	r *http.Request

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,6 @@
 module github.com/gomodule/oauth1
+
+require (
+	golang.org/x/net v0.0.0-20190509222800-a4d6f7feada5
+	google.golang.org/appengine v1.5.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,3 @@
 module github.com/gomodule/oauth1
 
-require (
-	golang.org/x/net v0.0.0-20190509222800-a4d6f7feada5
-	google.golang.org/appengine v1.5.0
-)
+require google.golang.org/appengine v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190509222800-a4d6f7feada5 h1:6M3SDHlHHDCx2PcQw3S4KsR170vGqDhJDOmpVd4Hjak=
+golang.org/x/net v0.0.0-20190509222800-a4d6f7feada5/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
+google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,7 @@
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225 h1:kNX+jCowfMYzvlSvJu5pQWEmyWFrBXJ3PBy10xKMXK8=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190509222800-a4d6f7feada5 h1:6M3SDHlHHDCx2PcQw3S4KsR170vGqDhJDOmpVd4Hjak=
-golang.org/x/net v0.0.0-20190509222800-a4d6f7feada5/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/oauth/examples_test.go
+++ b/oauth/examples_test.go
@@ -51,7 +51,9 @@ func ExampleClient_SetAuthorizationHeader(client *oauth.Client, credentials *oau
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	// process the response
 	return nil
 }

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -294,7 +294,7 @@ func TestRequestToken(t *testing.T) {
 	defer ts.Close()
 
 	for _, method = range []string{"", "GET", "POST"} {
-		c := Client{TokenRequestURI: ts.URL, TokenCredentailsMethod: method}
+		c := Client{TokenRequestURI: ts.URL, TokenCredentialsMethod: method}
 		cred, _, err := c.RequestToken(http.DefaultClient, &Credentials{}, "verifier")
 		if err != nil {
 			t.Errorf("returned error %v", err)

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -16,6 +16,7 @@ package oauth
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"io"
@@ -26,8 +27,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func parseURL(urlStr string) *url.URL {


### PR DESCRIPTION
Hi,

First at all, thanks for your work on this package.

The purpose of this pull request is to add the following features:

1. Add the management of the signature method RSA-SHA256.
1. Add the management of the `oauth_body_hash` parameter in OAuth header. In order to not break the method's signature, a new one is created to manage it: SetAuthorizationHeaderWithBody.
1- Fixes some golint errors.
1. Using of constants instead of plain text for header and parameters.
1. Using of context package instead of golang.org/x/net/context to remove external dependency. Go version required >1.7.

Thanks,