### PR TITLE
adds writeBaseString failing test

### DIFF
--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -198,8 +198,10 @@ func writeBaseString(w io.Writer, method string, u *url.URL, form url.Values, oa
 	w.Write(encode(scheme, false))
 	w.Write(encode("://", false))
 	w.Write(encode(host, false))
+	if len(path) > 0 && path[:1] != "/" {
+		w.Write(encode("/", false))
+	}
 	w.Write(encode(path, false))
-	w.Write([]byte{'&'})
 
 	// Create sorted slice of encoded parameters. Parameter keys and values are
 	// double encoded in a single step. This is safe because double encoding
@@ -217,6 +219,10 @@ func writeBaseString(w io.Writer, method string, u *url.URL, form url.Values, oa
 	encodedAmp := encode("&", false)
 	encodedEqual := encode("=", false)
 	sep := false
+
+	if len(p) > 0 {
+		w.Write([]byte{'&'})
+	}
 	for _, kv := range p {
 		if sep {
 			w.Write(encodedAmp)

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -28,6 +29,56 @@ import (
 	"strings"
 	"testing"
 )
+
+type writeBaseStringTestInput struct {
+	url    string
+	path   string
+	method string
+}
+
+type writeBaseStringTest struct {
+	input  writeBaseStringTestInput
+	output string
+}
+
+var writeBaseStringTests = []writeBaseStringTest{
+	writeBaseStringTest{
+		input: writeBaseStringTestInput{
+			url:    "https://www.interactivebrokers.com",
+			path:   "tradingapi/v1/oauth/request_token",
+			method: "POST",
+		},
+		output: "POST&https%3A%2F%2Fwww.interactivebrokers.com%2Ftradingapi%2Fv1%2Foauth%2Frequest_token",
+	},
+}
+
+func TestWriteBaseSting(t *testing.T) {
+	var (
+		u   *url.URL
+		err error
+	)
+
+	for i, tt := range writeBaseStringTests {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			s := ""
+			buf := bytes.NewBufferString(s)
+
+			u, err = url.Parse(tt.input.url)
+			if err != nil {
+				t.Fatalf("err parsing url %s; %v", tt.input.url, err)
+			}
+
+			u.Path = tt.input.path
+			t.Logf("url string %s", u.String())
+
+			writeBaseString(buf, tt.input.method, u, url.Values{}, map[string]string{})
+
+			if buf.String() != tt.output {
+				t.Errorf("expected %s, received %s", tt.output, buf.String())
+			}
+		})
+	}
+}
 
 func parseURL(urlStr string) *url.URL {
 	u, err := url.Parse(urlStr)

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -50,6 +50,14 @@ var writeBaseStringTests = []writeBaseStringTest{
 		},
 		output: "POST&https%3A%2F%2Fwww.interactivebrokers.com%2Ftradingapi%2Fv1%2Foauth%2Frequest_token",
 	},
+	writeBaseStringTest{
+		input: writeBaseStringTestInput{
+			url:    "https://www.interactivebrokers.com",
+			path:   "/tradingapi/v1/oauth/request_token",
+			method: "POST",
+		},
+		output: "POST&https%3A%2F%2Fwww.interactivebrokers.com%2Ftradingapi%2Fv1%2Foauth%2Frequest_token",
+	},
 }
 
 func TestWriteBaseSting(t *testing.T) {


### PR DESCRIPTION
Have I done something wrong with this test?

```bash
$ go test ./oauth/ -v -run=TestWriteBaseSting
=== RUN   TestWriteBaseSting
=== RUN   TestWriteBaseSting/0
    oauth_test.go:72: url string https://www.interactivebrokers.com/tradingapi/v1/oauth/request_token
    oauth_test.go:77: expected POST&https%3A%2F%2Fwww.interactivebrokers.com%2Ftradingapi%2Fv1%2Foauth%2Frequest_token, received POST&https%3A%2F%2Fwww.interactivebrokers.comtradingapi%2Fv1%2Foauth%2Frequest_token&
--- FAIL: TestWriteBaseSting (0.00s)
    --- FAIL: TestWriteBaseSting/0 (0.00s)
FAIL
FAIL    github.com/gomodule/oauth1/oauth        0.003s
FAIL
```